### PR TITLE
Remove attr_accessible.

### DIFF
--- a/lib/devise_security_extension/models/old_password.rb
+++ b/lib/devise_security_extension/models/old_password.rb
@@ -1,5 +1,3 @@
 class OldPassword < ActiveRecord::Base
   belongs_to :password_archivable, :polymorphic => true
-
-  attr_accessible :encrypted_password, :password_salt
 end

--- a/lib/devise_security_extension/models/security_question.rb
+++ b/lib/devise_security_extension/models/security_question.rb
@@ -1,3 +1,2 @@
 class SecurityQuestion < ActiveRecord::Base
-  attr_accessor :locale, :name
 end


### PR DESCRIPTION
`attr_accessible` is not available in Rails4, and is not necessary for
usage of this gem.

See upstream commits where this was already done:

- https://github.com/phatworx/devise_security_extension/commit/693b56171e1b4d8e02275ffd63ec522c7af87d9e
- https://github.com/phatworx/devise_security_extension/commit/1642da84469ee0da3b289e0a7a35f84fe66f5b52